### PR TITLE
Add Static API Authentication with Bearer Token

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -34,10 +34,14 @@ class Factory
     protected string $tenant = 'default_tenant';
 
     /**
+     * The bearer token used for authentication.
+     */
+    protected string $bearerToken;
+
+    /**
      * The http client to use for the requests.
      */
     protected \GuzzleHttp\Client $httpClient;
-
 
     /**
      * The ChromaDB api provider for the instance.
@@ -81,6 +85,15 @@ class Factory
     }
 
     /**
+     * The bearer token used for authentication the requests.
+     */
+    public function withBearerToken(string $bearerToken): self
+    {
+        $this->bearerToken = $bearerToken;
+        return $this;
+    }
+
+    /**
      * The http client to use for the requests.
      */
     public function withHttpClient(\GuzzleHttp\Client $httpClient): self
@@ -100,12 +113,18 @@ class Factory
     {
         $this->baseUrl = $this->host . ':' . $this->port;
 
-        $this->httpClient ??=  new \GuzzleHttp\Client([
+        $headers = [
+            'Content-Type' => 'application/json',
+            'Accept' => 'application/json',
+        ];
+
+        if (!empty($this->bearerToken)) {
+            $headers['Authorization'] = 'Bearer ' . $this->bearerToken;
+        }
+
+        $this->httpClient ??= new \GuzzleHttp\Client([
             'base_uri' => $this->baseUrl,
-            'headers' => [
-                'Content-Type' => 'application/json',
-                'Accept' => 'application/json'
-            ],
+            'headers' => $headers,
         ]);
 
         return new ChromaApiClient($this->httpClient);


### PR DESCRIPTION
# Add Bearer Token Support to ChromaDB

## Overview
This pull request introduces the capability to include a bearer token in the HTTP headers when making requests to ChromaDB. This feature enhances the `createApiClient` function within the existing client setup, allowing for authenticated requests to ChromaDB.

## Changes
- Added the ``bearerToken`` attribute to the ``Factory`` class
- Modified the `createApiClient` method to conditionally add the `Authorization` header if a bearer token is provided.

## Usage
Users who wish to make authenticated requests can now simply use the ``withBearerToken`` method when constructing the client. For example:
```php
$chromaDB = ChromaDB::factory()
                ->withHost('http://localhost')
                ->withPort(8000)
                ->withDatabase('new_database')
                ->withTenant('new_tenant')
                ->withBearerToken('my-secret-token')
                ->connect(); 
```

## Required Environment Variables for ChromaDB
To utilize the bearer token authentication feature, the following environment variables need to be set on the ChromaDB server. More information [here](https://docs.trychroma.com/usage-guide#authentication):
```env
CHROMA_SERVER_AUTH_CREDENTIALS="my-secret-token"
CHROMA_SERVER_AUTH_CREDENTIALS_PROVIDER="chromadb.auth.token.TokenConfigServerAuthCredentialsProvider"
CHROMA_SERVER_AUTH_PROVIDER="chromadb.auth.token.TokenAuthServerProvider"
```