### PR TITLE
Add static api authentication with bearer token

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,19 @@ jobs:
     name: Tests on PHP ${{ matrix.php }} - ${{ matrix.dependency-version }}
 
     services:
-      chroma:
+      chroma-wo-auth:
         image: chromadb/chroma
         ports:
           - 8000:8000
+
+      chroma-w-auth:
+        image: chromadb/chroma
+        ports:
+          - 8001:8000
+        env:
+          CHROMA_SERVER_AUTH_CREDENTIALS: 'test-token'
+          CHROMA_SERVER_AUTH_CREDENTIALS_PROVIDER: 'chromadb.auth.token.TokenConfigServerAuthCredentialsProvider'
+          CHROMA_SERVER_AUTH_PROVIDER: 'chromadb.auth.token.TokenAuthServerProvider'
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ composer require codewithkyrian/chromadb-php
 ```php
 use Codewithkyrian\ChromaDB\ChromaDB;
 
-$chromaDB = ChromaDB::client();
+$chroma = ChromaDB::client();
 
 ```
 
@@ -147,7 +147,7 @@ factory method:
 ```php
 use Codewithkyrian\ChromaDB\ChromaDB;
 
-$chromaDB = ChromaDB::factory()
+$chroma = ChromaDB::factory()
                 ->withHost('http://localhost')
                 ->withPort(8000)
                 ->withDatabase('new_database')
@@ -156,6 +156,47 @@ $chromaDB = ChromaDB::factory()
 ```
 
 If the tenant or database doesn't exist, the package will automatically create them for you.
+
+### Authentication
+
+ChromaDB supports static token-based authentication. To use it, you need to start the Chroma server passing the required
+environment variables as stated in the documentation. If you're using the docker image, you can pass in the environment
+variables using the `--env` flag or by using a `.env` file and for the docker-compose file, you can use the `env_file`
+option, or pass in the environment variables directly like so:
+
+```yaml
+version: '3.9'
+  
+services:
+  chroma:
+    image: 'chromadb/chroma'
+    ports:
+      - '8000:8000'
+    environment:
+      - CHROMA_SERVER_AUTH_CREDENTIALS=test-token
+      - CHROMA_SERVER_AUTH_CREDENTIALS_PROVIDER=chromadb.auth.token.TokenConfigServerAuthCredentialsProvider
+      - CHROMA_SERVER_AUTH_PROVIDER=chromadb.auth.token.TokenAuthServerProvider
+      
+    ...
+```   
+    
+You can then connect to ChromaDB using the factory method:
+
+```php
+use Codewithkyrian\ChromaDB\ChromaDB;
+
+$chroma = ChromaDB::factory()
+                ->withAuthToken('test-token')
+                ->connect();                
+```
+
+### Getting the version
+
+```php
+
+echo $chroma->version(); // 0.4.0
+
+```
 
 ### Creating a Collection
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,16 @@
 version: '3.9'
 
 services:
-  server:
+  chroma_wo_auth:
     image: 'chromadb/chroma'
     ports:
       - '8000:8000'
-    volumes:
-      - chroma-data:/chroma/chroma
 
-volumes:
-  chroma-data:
-    driver: local
+  chroma_w_auth:
+    image: 'chromadb/chroma'
+    ports:
+      - '8001:8000'
+    environment:
+      CHROMA_SERVER_AUTH_CREDENTIALS: 'test-token'
+      CHROMA_SERVER_AUTH_CREDENTIALS_PROVIDER: 'chromadb.auth.token.TokenConfigServerAuthCredentialsProvider'
+      CHROMA_SERVER_AUTH_PROVIDER: 'chromadb.auth.token.TokenAuthServerProvider'

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -34,10 +34,14 @@ class Factory
     protected string $tenant = 'default_tenant';
 
     /**
+     * The bearer token used for authentication.
+     */
+    protected string $bearerToken;
+
+    /**
      * The http client to use for the requests.
      */
     protected \GuzzleHttp\Client $httpClient;
-
 
     /**
      * The ChromaDB api provider for the instance.
@@ -81,6 +85,15 @@ class Factory
     }
 
     /**
+     * The bearer token used to authenticate requests.
+     */
+    public function withBearerToken(string $bearerToken): self
+    {
+        $this->bearerToken = $bearerToken;
+        return $this;
+    }
+
+    /**
      * The http client to use for the requests.
      */
     public function withHttpClient(\GuzzleHttp\Client $httpClient): self
@@ -100,12 +113,18 @@ class Factory
     {
         $this->baseUrl = $this->host . ':' . $this->port;
 
-        $this->httpClient ??=  new \GuzzleHttp\Client([
+        $headers = [
+            'Content-Type' => 'application/json',
+            'Accept' => 'application/json',
+        ];
+
+        if (!empty($this->bearerToken)) {
+            $headers['Authorization'] = 'Bearer ' . $this->bearerToken;
+        }
+
+        $this->httpClient ??= new \GuzzleHttp\Client([
             'base_uri' => $this->baseUrl,
-            'headers' => [
-                'Content-Type' => 'application/json',
-                'Accept' => 'application/json'
-            ],
+            'headers' => $headers,
         ]);
 
         return new ChromaApiClient($this->httpClient);

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -36,7 +36,7 @@ class Factory
     /**
      * The bearer token used for authentication.
      */
-    protected string $bearerToken;
+    protected string $authToken;
 
     /**
      * The http client to use for the requests.
@@ -87,9 +87,9 @@ class Factory
     /**
      * The bearer token used to authenticate requests.
      */
-    public function withBearerToken(string $bearerToken): self
+    public function withAuthToken(string $authToken): self
     {
-        $this->bearerToken = $bearerToken;
+        $this->authToken = $authToken;
         return $this;
     }
 
@@ -118,8 +118,8 @@ class Factory
             'Accept' => 'application/json',
         ];
 
-        if (!empty($this->bearerToken)) {
-            $headers['Authorization'] = 'Bearer ' . $this->bearerToken;
+        if (!empty($this->authToken)) {
+            $headers['Authorization'] = 'Bearer ' . $this->authToken;
         }
 
         $this->httpClient ??= new \GuzzleHttp\Client([

--- a/src/Generated/ChromaApiClient.php
+++ b/src/Generated/ChromaApiClient.php
@@ -357,9 +357,14 @@ class ChromaApiClient
                     ChromaException::throwSpecific($message, $error_type, $e->getCode());
                 }
 
+                // If the structure is {'error': 'Error Type', 'message' : 'Error message'}
+                if (isset($error['error']) && isset($error['message'])) {
+                    ChromaException::throwSpecific($error['message'], $error['error'], $e->getCode());
+                }
+
                 // If the structure is 'error' => 'Collection not found'
                 if (isset($error['error'])) {
-                    $message = $error['message'] ?? $error['error'];
+                    $message = $error['error'];
                     $error_type = ChromaException::inferTypeFromMessage($message);
 
                     ChromaException::throwSpecific($message, $error_type, $e->getCode());

--- a/src/Generated/ChromaApiClient.php
+++ b/src/Generated/ChromaApiClient.php
@@ -318,7 +318,7 @@ class ChromaApiClient
 
     private function handleChromaApiException(\Exception|ClientExceptionInterface $e): void
     {
-        if ($e instanceof ServerException) {
+        if ($e instanceof ClientExceptionInterface) {
             $errorString = $e->getResponse()->getBody()->getContents();
 
             if (preg_match('/(?<={"\"error\"\:\")([^"]*)/', $errorString, $matches)) {
@@ -359,7 +359,7 @@ class ChromaApiClient
 
                 // If the structure is 'error' => 'Collection not found'
                 if (isset($error['error'])) {
-                    $message = $error['error'];
+                    $message = $error['message'] ?? $error['error'];
                     $error_type = ChromaException::inferTypeFromMessage($message);
 
                     ChromaException::throwSpecific($message, $error_type, $e->getCode());

--- a/src/Generated/Exceptions/ChromaAuthorizationException.php
+++ b/src/Generated/Exceptions/ChromaAuthorizationException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace Codewithkyrian\ChromaDB\Generated\Exceptions;
+
+class ChromaAuthorizationException extends ChromaException
+{
+
+}

--- a/src/Generated/Exceptions/ChromaException.php
+++ b/src/Generated/Exceptions/ChromaException.php
@@ -12,6 +12,7 @@ class ChromaException extends \Exception
     {
         throw match ($type) {
             'NotFoundError' => new ChromaNotFoundException($message, $code),
+            'AuthorizationError' => new ChromaAuthorizationException($message, $code),
             'ValueError' => new ChromaValueException($message, $code),
             'UniqueConstraintError' => new ChromaUniqueConstraintException($message, $code),
             'DimensionalityError' => new ChromaDimensionalityException($message, $code),

--- a/src/Generated/Exceptions/ChromaException.php
+++ b/src/Generated/Exceptions/ChromaException.php
@@ -26,6 +26,7 @@ class ChromaException extends \Exception
     {
         return match (true) {
             str_contains($message, 'NotFoundError') => 'NotFoundError',
+            str_contains($message, 'AuthorizationError') => 'AuthorizationError',
             str_contains($message, 'UniqueConstraintError') => 'UniqueConstraintError',
             str_contains($message, 'ValueError') => 'ValueError',
             str_contains($message, 'dimensionality') => 'DimensionalityError',

--- a/tests/ChromaDB.php
+++ b/tests/ChromaDB.php
@@ -24,7 +24,7 @@ it('can connect to a chroma server using factory', function () {
 test('can connect to an API token authenticated chroma server', function () {
     $client = ChromaDB::factory()
         ->withPort(8001)
-        ->withBearerToken('test-token')
+        ->withAuthToken('test-token')
         ->connect();
 
     expect($client)->toBeInstanceOf(Client::class);
@@ -33,7 +33,7 @@ test('can connect to an API token authenticated chroma server', function () {
 it('cannot connect to an API token authenticated chroma server with wrong token', function () {
     ChromaDB::factory()
         ->withPort(8001)
-        ->withBearerToken('wrong-token')
+        ->withAuthToken('wrong-token')
         ->connect();
 })->throws(ChromaAuthorizationException::class);
 

--- a/tests/ChromaDB.php
+++ b/tests/ChromaDB.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 use Codewithkyrian\ChromaDB\Client;
 use Codewithkyrian\ChromaDB\ChromaDB;
+use Codewithkyrian\ChromaDB\Generated\Exceptions\ChromaAuthorizationException;
 
-it('can create a client instance', function () {
+it('can connect to a normal chroma server', function () {
     $client = ChromaDB::client();
 
     expect($client)->toBeInstanceOf(Client::class);
 });
 
-it('can create a client instance via factory', function () {
+it('can connect to a chroma server using factory', function () {
     $client = ChromaDB::factory()
         ->withHost('http://localhost')
         ->withPort(8000)
@@ -19,3 +20,25 @@ it('can create a client instance via factory', function () {
 
     expect($client)->toBeInstanceOf(Client::class);
 });
+
+test('can connect to an API token authenticated chroma server', function () {
+    $client = ChromaDB::factory()
+        ->withPort(8001)
+        ->withBearerToken('test-token')
+        ->connect();
+
+    expect($client)->toBeInstanceOf(Client::class);
+});
+
+it('cannot connect to an API token authenticated chroma server with wrong token', function () {
+    ChromaDB::factory()
+        ->withPort(8001)
+        ->withBearerToken('wrong-token')
+        ->connect();
+})->throws(ChromaAuthorizationException::class);
+
+it('throws exception when connecting to API token authenticated chroma server with no token', function () {
+    ChromaDB::factory()
+        ->withPort(8001)
+        ->connect();
+})->throws(ChromaAuthorizationException::class);


### PR DESCRIPTION
# Add Bearer Token Support to ChromaDB

## Overview
This pull request introduces the capability to include a bearer token in the HTTP headers when making requests to ChromaDB. This feature enhances the `createApiClient` function within the existing client setup, allowing for authenticated requests to ChromaDB.

## Changes
- Added the ``bearerToken`` attribute to the ``Factory`` class
- Modified the `createApiClient` method to conditionally add the `Authorization` header if a bearer token is provided.

## Usage
Users who wish to make authenticated requests can now simply use the ``withBearerToken`` method when constructing the client. For example:
```php
$chromaDB = ChromaDB::factory()
                ->withHost('http://localhost')
                ->withPort(8000)
                ->withDatabase('new_database')
                ->withTenant('new_tenant')
                ->withBearerToken('my-secret-token')
                ->connect(); 
```

## Required Environment Variables for ChromaDB
To utilize the bearer token authentication feature, the following environment variables need to be set on the ChromaDB server. More information [here](https://docs.trychroma.com/usage-guide#authentication):
```env
CHROMA_SERVER_AUTH_CREDENTIALS="my-secret-token"
CHROMA_SERVER_AUTH_CREDENTIALS_PROVIDER="chromadb.auth.token.TokenConfigServerAuthCredentialsProvider"
CHROMA_SERVER_AUTH_PROVIDER="chromadb.auth.token.TokenAuthServerProvider"
```