### PR TITLE
New environment variables

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,9 +25,8 @@ jobs:
         ports:
           - 8001:8000
         env:
-          CHROMA_SERVER_AUTH_CREDENTIALS: 'test-token'
-          CHROMA_SERVER_AUTH_CREDENTIALS_PROVIDER: 'chromadb.auth.token.TokenConfigServerAuthCredentialsProvider'
-          CHROMA_SERVER_AUTH_PROVIDER: 'chromadb.auth.token.TokenAuthServerProvider'
+          CHROMA_SERVER_AUTHN_CREDENTIALS: 'test-token'
+          CHROMA_SERVER_AUTHN_PROVIDER: 'chromadb.auth.token_authn.TokenAuthenticationServerProvider'
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -178,9 +178,8 @@ services:
     ports:
       - '8000:8000'
     environment:
-      - CHROMA_SERVER_AUTH_CREDENTIALS=test-token
-      - CHROMA_SERVER_AUTH_CREDENTIALS_PROVIDER=chromadb.auth.token.TokenConfigServerAuthCredentialsProvider
-      - CHROMA_SERVER_AUTH_PROVIDER=chromadb.auth.token.TokenAuthServerProvider
+      - CHROMA_SERVER_AUTHN_CREDENTIALS=test-token
+      - CHROMA_SERVER_AUTHN_PROVIDER=chromadb.auth.token_authn.TokenAuthenticationServerProvider
       
     ...
 ```   

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,5 @@ services:
     ports:
       - '8001:8000'
     environment:
-      CHROMA_SERVER_AUTH_CREDENTIALS: 'test-token'
-      CHROMA_SERVER_AUTH_CREDENTIALS_PROVIDER: 'chromadb.auth.token.TokenConfigServerAuthCredentialsProvider'
-      CHROMA_SERVER_AUTH_PROVIDER: 'chromadb.auth.token.TokenAuthServerProvider'
+      CHROMA_SERVER_AUTHN_CREDENTIALS: 'test-token'
+      CHROMA_SERVER_AUTHN_PROVIDER: 'chromadb.auth.token_authn.TokenAuthenticationServerProvider'

--- a/src/Generated/Exceptions/ChromaException.php
+++ b/src/Generated/Exceptions/ChromaException.php
@@ -27,6 +27,7 @@ class ChromaException extends \Exception
         return match (true) {
             str_contains($message, 'NotFoundError') => 'NotFoundError',
             str_contains($message, 'AuthorizationError') => 'AuthorizationError',
+            str_contains($message, 'Forbidden') => 'AuthorizationError',
             str_contains($message, 'UniqueConstraintError') => 'UniqueConstraintError',
             str_contains($message, 'ValueError') => 'ValueError',
             str_contains($message, 'dimensionality') => 'DimensionalityError',


### PR DESCRIPTION
The new minor version of ChromaDB (0.5.0) introduces changes to the auth environment variables, see [here](https://docs.trychroma.com/deployment/auth#static-api-token-authentication)

To align with these changes, we need to update the environement variables as follows:
```bash
export CHROMA_SERVER_AUTHN_CREDENTIALS="test-token"
export CHROMA_SERVER_AUTHN_PROVIDER="chromadb.auth.token_authn.TokenAuthenticationServerProvider"
```